### PR TITLE
REMOVE calls to domain.remove

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -51,12 +51,7 @@ module.exports = function(logger) {
     cleanDomain = function() {
       requestDomain.removeListener('error', domainErrorHandler);
       res.removeListener('finish', cleanDomain);
-      requestDomain.remove(req);
-      requestDomain.remove(res);
       requestDomain.exit();
-      requestDomain = null;
-      domainErrorHandler = null;
-      requestHandler = null;
     };
 
     res.on('finish', cleanDomain);

--- a/test/unit/domain-test.js
+++ b/test/unit/domain-test.js
@@ -56,8 +56,8 @@ describe('Domain Middleware Tests', function() {
       expect(domainSpy.add.withArgs(req).calledOnce).to.be.true;
       expect(domainSpy.add.withArgs(res).calledOnce).to.be.true;
       res.end();
-      expect(domainSpy.remove.withArgs(req).calledOnce).to.be.true;
-      expect(domainSpy.remove.withArgs(res).calledOnce).to.be.true;
+      expect(domainSpy.remove.withArgs(req).notCalled).to.be.true;
+      expect(domainSpy.remove.withArgs(res).notCalled).to.be.true;
       expect(domainSpy.exit.calledOnce).to.be.true;
       done();
     });
@@ -89,8 +89,8 @@ describe('Domain Middleware Tests', function() {
       expect(domainSpy.add.withArgs(res).calledOnce).to.be.true;
       // Trigger error
       domain.emit('error', new Error('test error'));
-      expect(domainSpy.remove.withArgs(req).calledOnce).to.be.true;
-      expect(domainSpy.remove.withArgs(res).calledOnce).to.be.true;
+      expect(domainSpy.remove.withArgs(req).notCalled).to.be.true;
+      expect(domainSpy.remove.withArgs(res).notCalled).to.be.true;
       expect(domainSpy.exit.calledOnce).to.be.true;
       done();
     });


### PR DESCRIPTION
Those two calls were causing a memory leak in node 0.10 because domain._stack were not properly cleaned.
