### PR TITLE
[[FEAT]] Finish errored request and rethrow error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Express middleware to automatically create and destroy a [domain](https://nodejs.org/api/domain.html).
 
+[READ THIS BEFORE USING THIS MODULE!](https://nodejs.org/api/domain.html#domain_domain)
+
+Allows you to respond to requests that had and unexpected error using your express error handlers and
+rethrows the exception to be captured by your own unhandledExcetion/cluster code
+
 [![npm version](https://badge.fury.io/js/express-domaining.svg)](http://badge.fury.io/js/express-domaining)
 [![Build Status](https://travis-ci.org/telefonica/node-express-domaining.svg)](https://travis-ci.org/telefonica/node-express-domaining)
 [![Coverage Status](https://img.shields.io/coveralls/telefonica/node-express-domaining.svg)](https://coveralls.io/r/telefonica/node-express-domaining)
@@ -20,19 +25,6 @@ var express = require('express'),
 
 var app = express();
 app.use(expressDomain());
-
-app.listen(3000);
-```
-
-By default, errors in domain are traced by `console.error`. However, you can use a custom logger:
-
-```js
-var express = require('express'),
-    expressDomain = require('express-domaining'),
-    logger = require('logops');
-
-var app = express();
-app.use(expressDomain(logger));
 
 app.listen(3000);
 ```

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -23,13 +23,9 @@ var domain = require('domain');
  * Express middleware that creates a domain per request in order to catch uncaught exceptions related
  * to the request.
  *
- * @param {Object} logger
- *    Optional logger to write errors in the domain. If not defined, it uses console as logger.
  * @return {Function(req, res, next)} Express middleware.
  */
-module.exports = function(logger) {
-
-  var errorLogger = logger || console;
+module.exports = function() {
 
   return function domainMiddleware(req, res, next) {
     var requestDomain = domain.create();
@@ -37,26 +33,26 @@ module.exports = function(logger) {
     // See https://nodejs.org/api/domain.html#domain_explicit_binding
     requestDomain.add(req);
     requestDomain.add(res);
-    var cleanDomain;
-
-    var domainErrorHandler = function(err) {
-      errorLogger.error(err);
-      cleanDomain();
-    };
-
-    var requestHandler = function() {
-      next();
-    };
-
-    cleanDomain = function() {
-      requestDomain.removeListener('error', domainErrorHandler);
-      res.removeListener('finish', cleanDomain);
-      requestDomain.exit();
-    };
-
     res.on('finish', cleanDomain);
     requestDomain.on('error', domainErrorHandler);
     requestDomain.enter();
-    requestDomain.run(requestHandler);
+    requestDomain.run(next);
+
+    function domainErrorHandler(err) {
+      cleanDomain();
+      // Pass to the user defined error handlers in express.
+      // This way the request can be finished with the user payloads the client may expect
+      // and logged.
+      next(err);
+      // rethrow to allow cluster code or unhandledException to manage it
+      // Usually, as this error is unexpected, the process should be terminated and restarted
+      throw err;
+    }
+
+    function cleanDomain() {
+      requestDomain.removeListener('error', domainErrorHandler);
+      res.removeListener('finish', cleanDomain);
+      requestDomain.exit();
+    }
   };
 };


### PR DESCRIPTION
Con la implementación actual, si un error ocurría durante la petición, este modulo simplemente la logaba, pero no respondía a la peticion del cliente con el error. Por lo tanto, la peticion se quedaba huérfana hasta que el cliente cancelara por timeout. 

Añadiendo una llamada a `next` con el error del dominio se consigue pasar el control al `errorHandler` que el usuario haya configurado en su servidor express. Este error handler es donde el usuario pone como manejar los errores para dar una respuesta unificada y logarlos. Por lo tanto, la dependencia de pasar un logger ya no es necesaria, reduciendo el acoplamiento.

Por otro lado, la implementación que simplemente loga y no hace nada más [está considerada una mala práctica](https://nodejs.org/api/domain.html#domain_warning_don_t_ignore_errors): 

``` js
// XXX WARNING!  BAD IDEA!

var d = require('domain').create();
d.on('error', (er) => {
  // The error won't crash the process, but what it does is worse!
  // Though we've prevented abrupt process restarting, we are leaking
  // resources like crazy if this ever happens.
  // This is no better than process.on('uncaughtException')!
  console.log('error, but oh well', er.message);
});
```

Añadiendo un throw del error en el dominio conseguimos pasar el control al `process.on('uncaughtException')` para [matar el servidor si se quiere](https://github.com/Telefonica/alfalfa/blob/master/src/startup.ts#L87-L92) o al código de un `cluster` para que reinicie el esclavo.

**BREAKING CHANGES:**
- No printing of error, and no need to pass logger,
  as the express error handler is used and the user can log the error there
- Errors are rethrown to allow cluster code or process.unhandledException code
  to respond to such errors, following best practices
