### PR TITLE
[[FIX]] Signal the process when error happens

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Express middleware to automatically create and destroy a [domain](https://nodejs
 [READ THIS BEFORE USING THIS MODULE!](https://nodejs.org/api/domain.html#domain_domain)
 
 Allows you to respond to requests that had and unexpected error using your express error handlers and
-rethrows the exception to be captured by your own unhandledExcetion/cluster code
+signal the process with a 'SIGTERM' to be captured by your own process/cluster code
 
 [![npm version](https://badge.fury.io/js/express-domaining.svg)](http://badge.fury.io/js/express-domaining)
 [![Build Status](https://travis-ci.org/telefonica/node-express-domaining.svg)](https://travis-ci.org/telefonica/node-express-domaining)

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -44,9 +44,7 @@ module.exports = function() {
       // This way the request can be finished with the user payloads the client may expect
       // and logged.
       next(err);
-      // rethrow to allow cluster code or unhandledException to manage it
-      // Usually, as this error is unexpected, the process should be terminated and restarted
-      throw err;
+      process.kill(process.pid, 'SIGTERM');
     }
 
     function cleanDomain() {


### PR DESCRIPTION
When executing inside a domain, the throw was captured by other pending requests domains that should not be affected by the unhandled error. That caused to end them abruptly. 

Signaling the process with SIGTERM allows capturing the signal outside the module and act accordingly
